### PR TITLE
Add OPENAI key setting

### DIFF
--- a/.env
+++ b/.env
@@ -1,3 +1,5 @@
 PAGE_ACCESS_TOKEN=your_facebook_page_access_token
 VERIFY_TOKEN=your_own_verify_token
 QDRANT_URL=http://localhost:6333
+
+OPENAI_API_KEY=your_openai_api_key

--- a/README.md
+++ b/README.md
@@ -1,0 +1,26 @@
+# MealMeBase RAG Chatbot
+
+This project is a simple RAG (Retrieval Augmented Generation) chatbot demo built with Node.js and Express.
+
+## Setup
+
+1. Install dependencies:
+   ```bash
+   npm install
+   ```
+
+2. Create a `.env` file in the project root (or update the existing one) with the following entries:
+   ```env
+   PAGE_ACCESS_TOKEN=your_facebook_page_access_token
+   VERIFY_TOKEN=your_own_verify_token
+   QDRANT_URL=http://localhost:6333
+   OPENAI_API_KEY=your_openai_api_key
+   ```
+   The `OPENAI_API_KEY` is required for generating embeddings and chatting with the OpenAI API.
+
+3. Start the server:
+   ```bash
+   npm start
+   ```
+
+The server will run on port defined by the `PORT` environment variable or `3000` by default.


### PR DESCRIPTION
## Summary
- add `OPENAI_API_KEY` to the `.env` file
- document environment variables in a new README

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_686b7eb75738832e88ac89243a7de19b