### PR TITLE
Improve chat error handling

### DIFF
--- a/index.js
+++ b/index.js
@@ -103,17 +103,24 @@ function chatHtml() {
     <button id="send">Send</button>
     <a href="/admin">Back to Admin</a>
     <script>
-      document.getElementById('send').addEventListener('click', async () => {
-        const msgEl = document.getElementById('msg');
-        const msg = msgEl.value;
-        if(!msg) return;
-        msgEl.value = '';
-        const chat = document.getElementById('messages');
-        chat.innerHTML += '<p><b>You:</b> '+msg+'</p>';
-        const res = await fetch('/chat', { method:'POST', headers:{'Content-Type':'application/json'}, body: JSON.stringify({ message: msg }) });
-        const data = await res.json();
-        chat.innerHTML += '<p><b>Bot:</b> '+data.answer+'</p>';
-      });
+        document.getElementById('send').addEventListener('click', async () => {
+          const msgEl = document.getElementById('msg');
+          const msg = msgEl.value;
+          if(!msg) return;
+          msgEl.value = '';
+          const chat = document.getElementById('messages');
+          chat.innerHTML += '<p><b>You:</b> '+msg+'</p>';
+          try {
+            const res = await fetch('/chat', { method:'POST', headers:{'Content-Type':'application/json'}, body: JSON.stringify({ message: msg }) });
+            const data = await res.json();
+            if (!res.ok || data.error) {
+              throw new Error(data.error);
+            }
+            chat.innerHTML += '<p><b>Bot:</b> '+data.answer+'</p>';
+          } catch (e) {
+            chat.innerHTML += '<p><b>Bot:</b> Failed to generate answer</p>';
+          }
+        });
     </script>
   `;
 }


### PR DESCRIPTION
## Summary
- handle errors from the `/chat` API call in the client-side script
- show a user-friendly message when the chatbot cannot produce an answer

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_686b7ebdb884832eb6be1979e253b277