### PR TITLE
Integrate Telegram bot

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,5 @@
+PAGE_ACCESS_TOKEN=your_facebook_page_access_token
+VERIFY_TOKEN=your_own_verify_token
+QDRANT_URL=http://localhost:6333
+OPENAI_API_KEY=your_openai_api_key
+TELEGRAM_BOT_TOKEN=your_telegram_bot_token

--- a/README.md
+++ b/README.md
@@ -17,7 +17,9 @@ The admin interface allows uploading knowledge sources used by the chatbot. You 
    VERIFY_TOKEN=your_own_verify_token
    QDRANT_URL=http://localhost:6333
    OPENAI_API_KEY=your_openai_api_key
+   TELEGRAM_BOT_TOKEN=your_telegram_bot_token
    ```
+   You can copy `.env.example` as a starting point and fill in your keys.
    The `OPENAI_API_KEY` is required for generating embeddings and chatting with the OpenAI API.
 
 3. Start the server:

--- a/index.js
+++ b/index.js
@@ -318,3 +318,27 @@ app.get('/', (req, res) => {
 
 const PORT = process.env.PORT || 3000;
 app.listen(PORT, () => console.log('Server running on port', PORT));
+
+// --- Telegram Bot Integration ---
+if (process.env.TELEGRAM_BOT_TOKEN) {
+  const TelegramBot = require('node-telegram-bot-api');
+  const bot = new TelegramBot(process.env.TELEGRAM_BOT_TOKEN, { polling: true });
+
+  bot.on('message', async (msg) => {
+    const chatId = msg.chat.id;
+    const text = msg.text?.trim();
+    if (!text) return;
+    try {
+      const context = await searchDocs(text);
+      const answer = await askLLM(context, text);
+      await bot.sendMessage(chatId, answer);
+    } catch (e) {
+      console.error('Telegram bot error:', e);
+      await bot.sendMessage(chatId, 'Failed to generate answer');
+    }
+  });
+
+  console.log('Telegram bot started');
+} else {
+  console.log('TELEGRAM_BOT_TOKEN not set, skipping Telegram bot startup');
+}

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "dotenv": "^17.0.1",
     "express": "^5.1.0",
     "langchain": "^0.3.29",
-    "qdrant-client": "^0.0.1"
+    "qdrant-client": "^0.0.1",
+    "node-telegram-bot-api": "^0.61.0"
   }
 }


### PR DESCRIPTION
## Summary
- add Telegram bot integration in `index.js`
- add `node-telegram-bot-api` dependency
- document TELEGRAM_BOT_TOKEN setup
- provide `.env.example` for quick configuration

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_686cf7621220832eb49f4d6782d5a1f5