### PR TITLE
Add JSON file support

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This project is a simple RAG (Retrieval Augmented Generation) chatbot demo built with Node.js and Express. The frontend is styled using [Tailwind CSS](https://tailwindcss.com) for a clean and modern look.
 
-The admin interface allows uploading knowledge sources used by the chatbot. You can now upload plain text **or** PDF documents.
+The admin interface allows uploading knowledge sources used by the chatbot. You can now upload plain text, **PDF**, or **JSON** documents.
 
 ## Setup
 


### PR DESCRIPTION
## Summary
- accept `.json` docs in admin panel
- parse uploaded JSON files into strings on both client and server
- validate JSON during ingestion
- document JSON upload support

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_686d517ca454832e8b2377bc10ddb3db