### PR TITLE
Add Telegram bot shutdown handlers

### DIFF
--- a/index.js
+++ b/index.js
@@ -505,6 +505,15 @@ if (process.env.TELEGRAM_BOT_TOKEN) {
   });
 
   console.log('Telegram bot started');
+
+  function shutdown() {
+    bot.stopPolling()
+      .catch((e) => console.error('Error stopping Telegram bot:', e))
+      .finally(() => process.exit());
+  }
+
+  process.once('SIGINT', shutdown);
+  process.once('SIGTERM', shutdown);
 } else {
   console.log('TELEGRAM_BOT_TOKEN not set, skipping Telegram bot startup');
 }


### PR DESCRIPTION
## Summary
- handle SIGINT and SIGTERM signals by stopping Telegram polling

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_686de4ee9438832e865cd9ef1f2594a5