### PR TITLE
Fix file upload size issue

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,7 +6,8 @@ const { QdrantClient } = require('@qdrant/js-client-rest');
 const fs = require('fs');
 
 const app = express();
-app.use(express.json());
+// Increase body size limit to handle large document uploads
+app.use(express.json({ limit: '25mb' }));
 
 const config = {
   instruction: '',


### PR DESCRIPTION
## Summary
- allow larger JSON request bodies by increasing Express body size limit

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_686e11400244832eaa6694b6f368d4d0