### PR TITLE
Add CSV file support

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This project is a simple RAG (Retrieval Augmented Generation) chatbot demo built with Node.js and Express. The frontend is styled using [Tailwind CSS](https://tailwindcss.com) for a clean and modern look.
 
-The admin interface allows uploading knowledge sources used by the chatbot. You can now upload plain text, **PDF**, or **JSON** documents.
+The admin interface allows uploading knowledge sources used by the chatbot. You can now upload plain text, **CSV**, **PDF**, or **JSON** documents.
 
 Telegram chat history from the bot is saved to `chathistory.json` and can be viewed in the "Chat History" page.
 

--- a/index.js
+++ b/index.js
@@ -199,7 +199,7 @@ function adminHtml() {
           </div>
           <div class="w-full">
             <label class="block font-semibold mb-1">Documents</label>
-            <input class="w-full border rounded px-3 py-2" type="file" id="file" accept=".txt,.pdf,.json" multiple />
+            <input class="w-full border rounded px-3 py-2" type="file" id="file" accept=".txt,.pdf,.json,.csv" multiple />
           </div>
           <div class="w-full">
             <button class="bg-blue-500 text-white px-4 py-2 rounded w-full" type="submit">Upload</button>
@@ -262,6 +262,9 @@ function adminHtml() {
             console.error('Invalid JSON file', e);
             return raw;
           }
+        }
+        if (file.type === 'text/csv' || file.name.toLowerCase().endsWith('.csv')) {
+          return await file.text();
         }
         return await file.text();
       }


### PR DESCRIPTION
## Summary
- allow CSV uploads in admin UI
- parse uploaded CSV files as text
- mention CSV files in docs

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_686e18eac820832ebf763f61153722ef