### PR TITLE
Fix invalid role in chat history

### DIFF
--- a/index.js
+++ b/index.js
@@ -136,7 +136,10 @@ async function askLLM(context, question, history = []) {
         model: 'gpt-4.1-mini',
         messages: [
           { role: 'system', content: config.instruction || 'You are a helpful assistant.' },
-          ...history.slice(-5).map(m => ({ role: m.role, content: m.text })),
+          ...history.slice(-5).map(m => ({
+            role: m.role === 'bot' ? 'assistant' : m.role,
+            content: m.text,
+          })),
           { role: 'user', content: context ? `${context}\n\n${question}` : question },
         ],
         temperature: config.temperature,


### PR DESCRIPTION
## Summary
- convert stored role `bot` to `assistant` before sending chat history to OpenAI

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_686e24eb4d6c832e9ac59b8daef5a1ea