### PR TITLE
Support multiple agents

### DIFF
--- a/agents.json
+++ b/agents.json
@@ -1,0 +1,11 @@
+{
+  "default": {
+    "id": "default",
+    "name": "Default Agent",
+    "instruction": "",
+    "temperature": 0.7,
+    "topP": 1,
+    "topK": 3,
+    "collection": "docs"
+  }
+}


### PR DESCRIPTION
## Summary
- allow multiple agents defined in `agents.json`
- manage agents with new routes `/agents`, `/admin/:id`, `/chat/:id`
- store per-agent doc collections and settings
- use first agent by default for Telegram and Viber bots

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6870c131682c832e9b85fccb527463c3