### PR TITLE
Add header logo support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,3 +5,4 @@ OPENAI_API_KEY=your_openai_api_key
 TELEGRAM_BOT_TOKEN=your_telegram_bot_token
 VIBER_AUTH_TOKEN=your_viber_auth_token
 VIBER_WEBHOOK_URL=https://your-domain.com
+LOGO_URL=https://ibb.co/HDy3fYZ8

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ Telegram chat history from the bot is saved to `chathistory.json` and can be vie
    TELEGRAM_BOT_TOKEN=your_telegram_bot_token
    VIBER_AUTH_TOKEN=your_viber_auth_token
    VIBER_WEBHOOK_URL=https://your-domain.com
+   LOGO_URL=https://ibb.co/HDy3fYZ8
    ```
    You can copy `.env.example` as a starting point and fill in your keys.
    The `OPENAI_API_KEY` is required for generating embeddings and chatting with the OpenAI API.

--- a/index.js
+++ b/index.js
@@ -5,6 +5,8 @@ const { CohereEmbeddings } = require('@langchain/cohere');
 const { QdrantClient } = require('@qdrant/js-client-rest');
 const fs = require('fs');
 
+const LOGO_URL = process.env.LOGO_URL || 'https://ibb.co/HDy3fYZ8';
+
 const app = express();
 // Increase body size limit to handle large document uploads
 app.use(express.json({ limit: '25mb' }));
@@ -191,6 +193,10 @@ function pageTemplate(content) {
         </style>
       </head>
       <body class="bg-gray-100 min-h-screen">
+        <header class="bg-white shadow p-4 mb-4 flex items-center">
+          <img src="${LOGO_URL}" alt="Logo" class="h-12 mr-3" />
+          <span class="text-xl font-bold">RAG Chatbot</span>
+        </header>
         <section class="min-h-screen w-full flex flex-col px-2 py-4">
           <div class="flex-1 flex flex-col w-full">${content}</div>
         </section>


### PR DESCRIPTION
## Summary
- show new site logo in page template
- allow customizing via `LOGO_URL` env var
- document `LOGO_URL` in README and `.env.example`

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6870ca1fd6d8832ea864c18aa023f2c7