### PR TITLE
Add Telegram token configuration per agent

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,6 +3,7 @@ VERIFY_TOKEN=your_own_verify_token
 QDRANT_URL=http://localhost:6333
 OPENAI_API_KEY=your_openai_api_key
 TELEGRAM_BOT_TOKEN=your_telegram_bot_token
+TELEGRAM_AGENT_ID=default
 VIBER_AUTH_TOKEN=your_viber_auth_token
 VIBER_WEBHOOK_URL=https://your-domain.com
 LOGO_URL=https://ibb.co/HDy3fYZ8

--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ Telegram chat history from the bot is saved to `chathistory.json` and can be vie
    You can copy `.env.example` as a starting point and fill in your keys.
    The `OPENAI_API_KEY` is required for generating embeddings and chatting with the OpenAI API.
    The `VIBER_AUTH_TOKEN` and `VIBER_WEBHOOK_URL` are used to configure the Viber webhook integration.
+   You can also set a Telegram bot token for each agent in the Admin page. If the `TELEGRAM_BOT_TOKEN` environment variable is not provided, the token from the agent selected by `TELEGRAM_AGENT_ID` will be used instead.
 
 3. Start the server:
    ```bash

--- a/agents.json
+++ b/agents.json
@@ -6,6 +6,7 @@
     "temperature": 0.7,
     "topP": 1,
     "topK": 3,
-    "collection": "docs"
+    "collection": "docs",
+    "telegramToken": ""
   }
 }

--- a/index.js
+++ b/index.js
@@ -35,6 +35,7 @@ if (Object.keys(agents).length === 0) {
     topP: 1,
     topK: 3,
     collection: 'docs',
+    telegramToken: '',
   };
   saveAgents();
 }
@@ -236,6 +237,10 @@ function adminHtml(agent) {
             <input class="w-full border rounded px-3 py-2" id="topK" type="number" value="${agent.topK}" />
           </div>
           <div class="w-full">
+            <label class="block font-semibold mb-1">Telegram Bot Token</label>
+            <input class="w-full border rounded px-3 py-2" id="telegramToken" value="${agent.telegramToken || ''}" />
+          </div>
+          <div class="w-full">
             <label class="block font-semibold mb-1">Documents</label>
             <input class="w-full border rounded px-3 py-2" type="file" id="file" accept=".txt,.pdf,.json,.csv" multiple />
           </div>
@@ -320,6 +325,7 @@ function adminHtml(agent) {
           temperature: parseFloat(document.getElementById('temperature').value),
           topP: parseFloat(document.getElementById('topP').value),
           topK: parseInt(document.getElementById('topK').value, 10),
+          telegramToken: document.getElementById('telegramToken').value.trim(),
           files: docs,
         };
         const res = await fetch('/admin/${agent.id}', {
@@ -604,7 +610,7 @@ app.post('/agents', async (req, res) => {
   const { name } = req.body;
   const id = 'a' + Date.now();
   const collection = `agent_${id}`;
-  agents[id] = { id, name: name || 'Agent', instruction: '', temperature: 0.7, topP: 1, topK: 3, collection };
+  agents[id] = { id, name: name || 'Agent', instruction: '', temperature: 0.7, topP: 1, topK: 3, collection, telegramToken: '' };
   try {
     await ensureCollection(collection);
     saveAgents();
@@ -633,11 +639,12 @@ app.post('/admin/:id', async (req, res) => {
   const agent = agents[req.params.id];
   if (!agent) return res.status(404).json({ error: 'Agent not found' });
   console.log('ADMIN POST', req.body);
-  const { instruction, temperature, topP, topK, files = [], text } = req.body;
+  const { instruction, temperature, topP, topK, telegramToken, files = [], text } = req.body;
   if (instruction !== undefined) agent.instruction = instruction;
   if (!isNaN(temperature)) agent.temperature = temperature;
   if (!isNaN(topP)) agent.topP = topP;
   if (!isNaN(topK)) agent.topK = topK;
+  if (telegramToken !== undefined) agent.telegramToken = telegramToken;
   if (files && Array.isArray(files)) {
     for (const f of files) {
       if (!f || !f.text) continue;
@@ -727,10 +734,11 @@ app.listen(PORT, () => console.log('Server running on port', PORT));
 const defaultAgent = agents[process.env.TELEGRAM_AGENT_ID] || Object.values(agents)[0];
 
 // --- Telegram Bot Integration ---
-if (process.env.TELEGRAM_BOT_TOKEN) {
+const telegramToken = process.env.TELEGRAM_BOT_TOKEN || (defaultAgent && defaultAgent.telegramToken);
+if (telegramToken) {
   const TelegramBot = require('node-telegram-bot-api');
   // Use manual start for polling so we can handle conflicts
-  const bot = new TelegramBot(process.env.TELEGRAM_BOT_TOKEN, {
+  const bot = new TelegramBot(telegramToken, {
     polling: { autoStart: false },
   });
 
@@ -799,7 +807,7 @@ if (process.env.TELEGRAM_BOT_TOKEN) {
   process.once('SIGINT', shutdown);
   process.once('SIGTERM', shutdown);
 } else {
-  console.log('TELEGRAM_BOT_TOKEN not set, skipping Telegram bot startup');
+  console.log('No Telegram token found, skipping Telegram bot startup');
 }
 
 // --- Viber Bot Integration ---


### PR DESCRIPTION
## Summary
- allow specifying a `telegramToken` per agent
- show a Telegram Bot Token field in the admin UI
- use agent token when `TELEGRAM_BOT_TOKEN` env var isn't set
- document new behaviour and env variable
- update example environment file

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6870d6f66d24832eacf7f565c1a50677